### PR TITLE
fix: image format output

### DIFF
--- a/installers/rockpi4/src/main.go
+++ b/installers/rockpi4/src/main.go
@@ -56,7 +56,7 @@ func (i *rockPi4) Install(options overlay.InstallOptions[rockPi4ExtraOptions]) e
 
 	defer f.Close() //nolint:errcheck
 
-	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "artifacts/arm64/u-boot/rockpi4/u-boot-rockchip.bin"))
+	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot/rockpi4/u-boot-rockchip.bin"))
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func (i *rockPi4) Install(options overlay.InstallOptions[rockPi4ExtraOptions]) e
 		return err
 	}
 
-	src := filepath.Join(options.ArtifactsPath, "artifacts/arm64/dtb", dtb)
+	src := filepath.Join(options.ArtifactsPath, "arm64/dtb", dtb)
 	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtb)
 
 	err = os.MkdirAll(filepath.Dir(dst), 0o600)

--- a/installers/rockpi4c/src/main.go
+++ b/installers/rockpi4c/src/main.go
@@ -55,7 +55,7 @@ func (i *rockPi4) Install(options overlay.InstallOptions[rockPi4ExtraOptions]) e
 
 	defer f.Close() //nolint:errcheck
 
-	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "artifacts/arm64/u-boot/rockpi4/u-boot-rockchip.bin"))
+	uboot, err := os.ReadFile(filepath.Join(options.ArtifactsPath, "arm64/u-boot/rockpi4/u-boot-rockchip.bin"))
 	if err != nil {
 		return err
 	}
@@ -72,7 +72,7 @@ func (i *rockPi4) Install(options overlay.InstallOptions[rockPi4ExtraOptions]) e
 		return err
 	}
 
-	src := filepath.Join(options.ArtifactsPath, "artifacts/arm64/dtb", dtb)
+	src := filepath.Join(options.ArtifactsPath, "arm64/dtb", dtb)
 	dst := filepath.Join(options.MountPrefix, "/boot/EFI/dtb", dtb)
 
 	err = os.MkdirAll(filepath.Dir(dst), 0o600)

--- a/profiles/rockpi4/rockpi4.yaml
+++ b/profiles/rockpi4/rockpi4.yaml
@@ -3,7 +3,7 @@ platform: metal
 secureboot: false
 output:
   kind: image
-  outFormat: xz
+  outFormat: .xz
   imageOptions:
     diskSize: 1306525696
     diskFormat: raw

--- a/profiles/rockpi4c/rockpi4c.yaml
+++ b/profiles/rockpi4c/rockpi4c.yaml
@@ -3,7 +3,7 @@ platform: metal
 secureboot: false
 output:
   kind: image
-  outFormat: xz
+  outFormat: .xz
   imageOptions:
     diskSize: 1306525696
     diskFormat: raw


### PR DESCRIPTION
Use the correct image output format.
Fixes the artifacts path.